### PR TITLE
Added the ability to rip full XM modules with sample data

### DIFF
--- a/EPFExplorer/EPFExplorer.csproj
+++ b/EPFExplorer/EPFExplorer.csproj
@@ -122,6 +122,7 @@
     <Compile Include="src\FileTypes\xmfile.cs" />
     <EmbeddedResource Include="src\Forms\Form1.resx">
       <DependentUpon>Form1.cs</DependentUpon>
+      <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="Properties\Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>

--- a/EPFExplorer/src/FileTypes/binfile.cs
+++ b/EPFExplorer/src/FileTypes/binfile.cs
@@ -40,23 +40,6 @@ namespace EPFExplorer
 
         int offset_of_end_of_index_table = 0;
 
-        public int[] ima_index_table = new int[]{
-              -1, -1, -1, -1, 2, 4, 6, 8,
-              -1, -1, -1, -1, 2, 4, 6, 8
-            };
-
-        public int[] ima_step_table = new int[]{
-          7, 8, 9, 10, 11, 12, 13, 14, 16, 17,
-          19, 21, 23, 25, 28, 31, 34, 37, 41, 45,
-          50, 55, 60, 66, 73, 80, 88, 97, 107, 118,
-          130, 143, 157, 173, 190, 209, 230, 253, 279, 307,
-          337, 371, 408, 449, 494, 544, 598, 658, 724, 796,
-          876, 963, 1060, 1166, 1282, 1411, 1552, 1707, 1878, 2066,
-          2272, 2499, 2749, 3024, 3327, 3660, 4026, 4428, 4871, 5358,
-          5894, 6484, 7132, 7845, 8630, 9493, 10442, 11487, 12635, 13899,
-          15289, 16818, 18500, 20350, 22385, 24623, 27086, 29794, 32767
-        };
-
         public void ReadMusicBin()
         {
             using (BinaryReader reader = new BinaryReader(File.Open(filename, FileMode.Open)))
@@ -130,59 +113,100 @@ namespace EPFExplorer
 
                 samples = new sfxfile[samplecount];
 
-                int pos = (int)(offset_of_end_of_index_table + 76);
+                int pos = offset_of_end_of_index_table;
 
-                if (isHR)
-                    {
-                    pos += 4;
-                    }
-
-
-                bool keepgoing = true;
-
-                for (int i = 0; i < samplecount; i++)
-                    {
-                    List<byte> newSampleBytes = new List<byte>();
-
-                    int i_within_loop = i;
-
-                    uint offset = (uint)pos;
-
-                    while (keepgoing)
-                       {
-                        if (pos + 3 >= filebytes.Length)
-                            {
-                            keepgoing = false;
-                            i = samplecount - 1;
-                            }
-                        else if (filebytes[pos] == 0x02 && filebytes[pos + 1] == 0x00 && filebytes[pos + 2] == 0x40 && filebytes[pos + 3] == 0x00)
-                            {
-                            keepgoing = false;
-                            pos += 64;
-                            if (isHR)
-                                {
-                                pos += 4;
-                                }
-                        }
-                        else
-                            {
-                            newSampleBytes.Add(filebytes[pos]);
-                            pos++;
-                            }
-                        }
-
-                    newSampleBytes.RemoveRange(newSampleBytes.Count-0x13,0x13);
+                for (int i = 0; i < samplecount; i++) {
 
                     sfxfile newSample = new sfxfile();
+
+                    /*
+                     * So it turns out that the chunk of data at the top of each sample,
+                     * which was previously ignored, is actually chock full of information
+                     * about the sample, including some instrument parameters including
+                     * volume and panning envelopes. The previous behavior of splitting by
+                     * 0x02004000 was flawed as well - PCM samples would have 0x00004000 in
+                     * that place instead, causing all sorts of wacky issues when trying to
+                     * decode an ADPCM sample that is followed by one or more PCM samples
+                     * (this happened quite a bit during debugging).
+                     * 
+                     * To keep things sane for the future, I'm including a speculative
+                     * specification for the data contained in this chunk. Take this with a
+                     * grain of salt, but I believe it should be correct (as long as my ears
+                     * are working properly). Some of the descriptions may require
+                     * understanding of the format of XM instruments. This also doesn't
+                     * account for the reported 4 byte increase in size in HR - update this
+                     * for HR!!!
+                     * 
+                     * Offset  | Size     | Description
+                     * --------+----------+-------------------------------------------------
+                     * 0x00    | 4        | The size of the sample data divided by 4 minus 4. (Data size = this * 4 + 4)
+                     * 0x04    | 4        | The position of the start of the loop, or 0xFFFFFFFF for no loop. (?)
+                     * 0x08    | 4        | The position of the end of the loop, or size+1 for no loop. (?)
+                     * 0x0C    | 1        | The type of sample. 0 = s16 PCM, 2 = MS IMA ADPCM
+                     * 0x0D    | 1        | Unknown (always 0). Could be upper byte of above.
+                     * 0x0E    | 1        | Default volume for the sample.
+                     * 0x0F    | 1        | Unknown (always 0). Could be upper byte of above.
+                     * 0x10    | 1        | Finetune value. Stored as a signed byte.
+                     * 0x11    | 1        | Transpose value. Stored as a signed byte.
+                     * 0x12    | 1        | Default pan position. Stored as an unsigned byte, with 0x80 = center.
+                     * 0x13    | 1        | Unknown (always 0).
+                     * 0x14    | 1        | Number of nodes in the volume envelope.
+                     * 0x15    | 1        | Position of volume envelope sustain node, or 0xFF for no sustain.
+                     * 0x16    | 1        | Position of volume envelope loop start, or 0xFF for no loop.
+                     * 0x17    | 1        | Position of volume envelope loop end, or 0xFF for no loop.
+                     * 0x18    | 2*24     | Nodes in the volume envelope, alternating (x, y).
+                     * 0x48    | 1        | Number of nodes in the panning envelope.
+                     * 0x49    | 1        | Position of panning envelope sustain node, or 0xFF for no sustain.
+                     * 0x4A    | 1        | Position of panning envelope loop start, or 0xFF for no loop.
+                     * 0x4B    | 1        | Position of panning envelope loop end, or 0xFF for no loop.
+                     * 0x4C    | 2*24     | Nodes in the panning envelope, alternating (x, y).
+                     * 0x7C    | <size>   | The actual sample data.
+                     */
+
+                    uint offset = (uint)pos;
+                    int length = (filebytes[pos] | (filebytes[pos + 1] << 8) | (filebytes[pos + 2] << 16) | (filebytes[pos + 3] << 24)) * 4 + 4;
+                    newSample.isPCM = filebytes[pos + 12] != 2;
+                    newSample.finetune = (sbyte)filebytes[pos + 16];
+                    newSample.transpose = (sbyte)filebytes[pos + 17];
+                    newSample.defaultvol = filebytes[pos + 14];
+                    newSample.defaultpan = filebytes[pos + 18];
+
+                    newSample.volenv.count = filebytes[pos + 20];
+                    newSample.volenv.sustainPoint = filebytes[pos + 21];
+                    newSample.volenv.loopStart = filebytes[pos + 22];
+                    newSample.volenv.loopEnd = filebytes[pos + 23];
+                    for (int j = 0; j < 24; j++) {
+                        newSample.volenv.nodes[j] = (short)(filebytes[pos + j*2 + 24] | (filebytes[pos + j * 2 + 25] << 8));
+                    }
+
+                    newSample.panenv.count = filebytes[pos + 72];
+                    newSample.panenv.sustainPoint = filebytes[pos + 73];
+                    newSample.panenv.loopStart = filebytes[pos + 74];
+                    newSample.panenv.loopEnd = filebytes[pos + 75];
+                    for (int j = 0; j < 24; j++) {
+                        newSample.panenv.nodes[j] = (short)(filebytes[pos + j * 2 + 76] | (filebytes[pos + j * 2 + 77] << 8));
+                    }
+
+                    pos += 120;
+                    if (isHR) {
+                        pos += 4;
+                    }
+
                     newSample.parentbinfile = this;
 
                     newSample.samplerate = 44100;
-                    newSample.filebytes = newSampleBytes.ToArray();
+                    newSample.filebytes = new byte[length];
+                    Array.Copy(filebytes, pos, newSample.filebytes, 0, length);
                     newSample.offset = offset;
+                    pos += length;
+                    
 
-                    samples[i_within_loop] = newSample;
-                    keepgoing = true;
+                    samples[i] = newSample;
                     }
+
+                foreach (xmfile xm in xmfiles) {
+                    xm.samples = new List<sfxfile>(samples);
+                }
             }
         }
 

--- a/EPFExplorer/src/FileTypes/binfile.cs
+++ b/EPFExplorer/src/FileTypes/binfile.cs
@@ -148,6 +148,7 @@ namespace EPFExplorer
                      * 0x0F    | 1        | Unknown (always 0). Could be upper byte of above.
                      * 0x10    | 1        | Finetune value. Stored as a signed byte.
                      * 0x11    | 1        | Transpose value. Stored as a signed byte. (For some reason, if the sample is PCM you should decrease this value by 12.)
+                     * 0x12    | 0/4      | This field is present in HR but not EPF. Not sure what's in it yet.
                      * 0x12    | 1        | Default pan position. Stored as an unsigned byte, with 0x80 = center.
                      * 0x13    | 1        | Unknown (always 0).
                      * 0x14    | 1        | Number of nodes in the volume envelope.
@@ -172,28 +173,27 @@ namespace EPFExplorer
                     newSample.transpose = (sbyte)filebytes[pos + 17];
                     if (newSample.isPCM) newSample.transpose -= 12;
                     newSample.defaultvol = filebytes[pos + 14];
-                    newSample.defaultpan = filebytes[pos + 18];
+                    if (isHR) pos += 22;
+                    else pos += 18;
+                    newSample.defaultpan = filebytes[pos];
 
-                    newSample.volenv.count = filebytes[pos + 20];
-                    newSample.volenv.sustainPoint = filebytes[pos + 21];
-                    newSample.volenv.loopStart = filebytes[pos + 22];
-                    newSample.volenv.loopEnd = filebytes[pos + 23];
+                    newSample.volenv.count = filebytes[pos + 2];
+                    newSample.volenv.sustainPoint = filebytes[pos + 3];
+                    newSample.volenv.loopStart = filebytes[pos + 4];
+                    newSample.volenv.loopEnd = filebytes[pos + 5];
                     for (int j = 0; j < 24; j++) {
-                        newSample.volenv.nodes[j] = (short)(filebytes[pos + j*2 + 24] | (filebytes[pos + j * 2 + 25] << 8));
+                        newSample.volenv.nodes[j] = (short)(filebytes[pos + j*2 + 6] | (filebytes[pos + j * 2 + 7] << 8));
                     }
 
-                    newSample.panenv.count = filebytes[pos + 72];
-                    newSample.panenv.sustainPoint = filebytes[pos + 73];
-                    newSample.panenv.loopStart = filebytes[pos + 74];
-                    newSample.panenv.loopEnd = filebytes[pos + 75];
+                    newSample.panenv.count = filebytes[pos + 54];
+                    newSample.panenv.sustainPoint = filebytes[pos + 55];
+                    newSample.panenv.loopStart = filebytes[pos + 56];
+                    newSample.panenv.loopEnd = filebytes[pos + 57];
                     for (int j = 0; j < 24; j++) {
-                        newSample.panenv.nodes[j] = (short)(filebytes[pos + j * 2 + 76] | (filebytes[pos + j * 2 + 77] << 8));
+                        newSample.panenv.nodes[j] = (short)(filebytes[pos + j * 2 + 58] | (filebytes[pos + j * 2 + 59] << 8));
                     }
 
-                    pos += 124;
-                    if (isHR) {
-                        pos += 4;
-                    }
+                    pos += 106;
 
                     newSample.parentbinfile = this;
 

--- a/EPFExplorer/src/FileTypes/binfile.cs
+++ b/EPFExplorer/src/FileTypes/binfile.cs
@@ -133,9 +133,7 @@ namespace EPFExplorer
                      * specification for the data contained in this chunk. Take this with a
                      * grain of salt, but I believe it should be correct (as long as my ears
                      * are working properly). Some of the descriptions may require
-                     * understanding of the format of XM instruments. This also doesn't
-                     * account for the reported 4 byte increase in size in HR - update this
-                     * for HR!!!
+                     * understanding of the format of XM instruments.
                      * 
                      * Offset  | Size     | Description
                      * --------+----------+-------------------------------------------------
@@ -148,7 +146,7 @@ namespace EPFExplorer
                      * 0x0F    | 1        | Unknown (always 0). Could be upper byte of above.
                      * 0x10    | 1        | Finetune value. Stored as a signed byte.
                      * 0x11    | 1        | Transpose value. Stored as a signed byte. (For some reason, if the sample is PCM you should decrease this value by 12.)
-                     * 0x12    | 0/4      | This field is present in HR but not EPF. Not sure what's in it yet.
+                     * 0x12    | 0/4      | This field is present in HR but not EPF. Not sure what's in it yet. If on HR, add 4 to each subsequent offset.
                      * 0x12    | 1        | Default pan position. Stored as an unsigned byte, with 0x80 = center.
                      * 0x13    | 1        | Unknown (always 0).
                      * 0x14    | 1        | Number of nodes in the volume envelope.

--- a/EPFExplorer/src/FileTypes/binfile.cs
+++ b/EPFExplorer/src/FileTypes/binfile.cs
@@ -177,6 +177,16 @@ namespace EPFExplorer
                     else pos += 18;
                     newSample.defaultpan = filebytes[pos];
 
+                    // Hot-patch for Snake Game samples, which have the wrong transpose
+                    // (also changing finetune since that seems to make it sound better)
+                    if (isHR) {
+                        if (i == 54 || i == 58 || i == 59) newSample.transpose--;
+                        if (i == 54 || i == 57 || i == 58 || i == 59) newSample.defaultpan = 0x80;
+                        if (i == 54) newSample.finetune = -16;
+                        else if (i == 57) newSample.finetune = -30;
+                        else if (i == 59) newSample.finetune = -26;
+                    }
+
                     newSample.volenv.count = filebytes[pos + 2];
                     newSample.volenv.sustainPoint = filebytes[pos + 3];
                     newSample.volenv.loopStart = filebytes[pos + 4];

--- a/EPFExplorer/src/FileTypes/binfile.cs
+++ b/EPFExplorer/src/FileTypes/binfile.cs
@@ -35,8 +35,8 @@ namespace EPFExplorer
 
         bool isHR = false;
 
-        public List<string> MusicNamesEPF = new List<string>() { "Main theme", "Unused UI theme", "Command Room", "Coffee Shop", "Ski Village", "HQ", "Town", "Gift Shop", "Ski Lodge", "Pizza Parlor", "Coffee Shop", "Test Robots theme", "Cart Surfer", "Ice Fishing", "Gadget Room", "Night Club", "Dojo", "Boiler Room", "Menu", "Stage", "Beach", "Mine Shack", "Mine", "Jet Pack Adventure", "Snowboarding", "Snow Trekker", "Mission Complete", "Nothing" };
-        public List<string> MusicNamesHR = new List<string>() { "Command Room", "Coffee Shop", "Ski Village", "HQ", "Town", "Gift Shop", "Ski Lodge", "Pizza Parlor", "Ice Fishing", "Gadget room", "Night Club", "Spy Snake", "Boiler room", "Menu", "Stage", "Beach", "Mine Shack", "Mine", "Grapple Gadget", "Main theme", "Herbert's Base", "Herbert's Base 2", "Herbert behind Ski Lodge", "Herbert's theme", "Geyser theme", "Unused", "Aqua Rescue", "Tallest Mountain", "Tallest Mountain 2", "Puffle Training Caves", "Spy Snake", "Credits" };
+        public List<string> MusicNamesEPF = new List<string>() { "Main Theme", "Unused UI Theme", "Command Room", "Coffee Shop (1)", "Ski Village", "HQ", "Town", "Gift Shop", "Ski Lodge", "Pizza Parlor", "Coffee Shop (2)", "Test Robots Theme", "Cart Surfer", "Ice Fishing", "Gadget Room", "Night Club", "Dojo", "Boiler Room", "Menu", "Stage", "Beach", "Mine Shack", "Mine", "Jet Pack Adventure", "Snowboarding", "Snow Trekker", "Mission Complete", "Nothing" };
+        public List<string> MusicNamesHR = new List<string>() { "Command Room", "Coffee Shop", "Ski Village", "HQ", "Town", "Gift Shop", "Ski Lodge", "Pizza Parlor", "Ice Fishing", "Gadget Room", "Night Club", "Spy Snake (1)", "Boiler Room", "Menu", "Stage", "Beach", "Mine Shack", "Mine", "Grapple Gadget", "Main Theme", "Herbert's Base", "Herbert's Base (Extended)", "Herbert behind Ski Lodge", "Herbert's Theme", "Geyser Theme", "Unused", "Aqua Rescue", "Tallest Mountain", "Tallest Mountain (Shortened)", "Puffle Training Caves", "Spy Snake (2)", "Credits" };
 
         int offset_of_end_of_index_table = 0;
 

--- a/EPFExplorer/src/FileTypes/sfxfile.cs
+++ b/EPFExplorer/src/FileTypes/sfxfile.cs
@@ -27,6 +27,8 @@ namespace EPFExplorer
         public sbyte transpose = 0x11;
         public byte defaultvol = 0x40;
         public byte defaultpan = 0x80;
+        public uint loopstart;
+        public uint loopend;
         public bool isPCM = false;
         public envelope volenv = new envelope();
         public envelope panenv = new envelope();

--- a/EPFExplorer/src/FileTypes/sfxfile.cs
+++ b/EPFExplorer/src/FileTypes/sfxfile.cs
@@ -10,16 +10,91 @@ namespace EPFExplorer
 {
     public class sfxfile
     {
+        public class envelope {
+            public short[] nodes = new short[24];
+            public int count;
+            public byte sustainPoint;
+            public byte loopStart;
+            public byte loopEnd;
+        }
 
         public uint offset;
         public byte[] filebytes;
         public uint filemagic;
         public uint sizedividedby4;
         public uint samplerate;
+        public sbyte finetune = 0;
+        public sbyte transpose = 0x11;
+        public byte defaultvol = 0x40;
+        public byte defaultpan = 0x80;
+        public bool isPCM = false;
+        public envelope volenv = new envelope();
+        public envelope panenv = new envelope();
         public uint unk1;
+
+        public static T Clamp<T>(T val, T min, T max) where T : IComparable<T> {
+            if (val.CompareTo(min) < 0) return min;
+            else if (val.CompareTo(max) > 0) return max;
+            else return val;
+        }
 
         public binfile parentbinfile;
 
+        private int[] ima_index_table = new int[]{
+              -1, -1, -1, -1, 2, 4, 6, 8,
+              -1, -1, -1, -1, 2, 4, 6, 8
+            };
+
+        private short[] ima_step_table = new short[]{
+          7, 8, 9, 10, 11, 12, 13, 14, 16, 17,
+          19, 21, 23, 25, 28, 31, 34, 37, 41, 45,
+          50, 55, 60, 66, 73, 80, 88, 97, 107, 118,
+          130, 143, 157, 173, 190, 209, 230, 253, 279, 307,
+          337, 371, 408, 449, 494, 544, 598, 658, 724, 796,
+          876, 963, 1060, 1166, 1282, 1411, 1552, 1707, 1878, 2066,
+          2272, 2499, 2749, 3024, 3327, 3660, 4026, 4428, 4871, 5358,
+          5894, 6484, 7132, 7845, 8630, 9493, 10442, 11487, 12635, 13899,
+          15289, 16818, 18500, 20350, 22385, 24623, 27086, 29794, 32767
+        };
+
+        public short[] ConvertToPCM() {
+            if (isPCM) {
+                short[] output = new short[filebytes.Length / 2];
+                for (int i = 0; i < filebytes.Length / 2; i++) {
+                    output[i] = (short)(filebytes[i * 2] | (filebytes[i * 2 + 1] << 8));
+                }
+                return output;
+            } else {
+                List<short> output = new List<short>();
+                int predictor = (filebytes[0] | (filebytes[1] << 8));
+                int step_index = filebytes[2], step;
+                for (int i = 4; i < filebytes.Length; i++) {
+                    int diff;
+                    byte nl = (byte)(filebytes[i] & 0x0f);
+                    step = ima_step_table[step_index];
+                    step_index = Clamp(step_index + ima_index_table[nl], 0, 88);
+                    diff = step >> 3;
+                    if ((nl & 4) != 0) diff += step;
+                    if ((nl & 2) != 0) diff += (step >> 1);
+                    if ((nl & 1) != 0) diff += (step >> 2);
+                    if ((nl & 8) != 0) predictor = Clamp(predictor - diff, -32768, 32767);
+                    else predictor = Clamp(predictor + diff, -32768, 32767);
+                    output.Add((short)predictor);
+
+                    nl = (byte)((filebytes[i] & 0xf0) >> 4);
+                    step = ima_step_table[step_index];
+                    step_index = Clamp(step_index + ima_index_table[nl], 0, 88);
+                    diff = step >> 3;
+                    if ((nl & 4) != 0) diff += step;
+                    if ((nl & 2) != 0) diff += (step >> 1);
+                    if ((nl & 1) != 0) diff += (step >> 2);
+                    if ((nl & 8) != 0) predictor = Clamp(predictor - diff, -32768, 32767);
+                    else predictor = Clamp(predictor + diff, -32768, 32767);
+                    output.Add((short)predictor);
+                }
+                return output.ToArray();
+            }
+        }
 
         public void Export() {
 
@@ -31,7 +106,7 @@ namespace EPFExplorer
 
                 saveFileDialog1.Title = "Save .wav file";
                 saveFileDialog1.CheckPathExists = true;
-                saveFileDialog1.Filter = "ADPCM WAV (*.wav)|*.wav|All files (*.*)|*.*";
+                saveFileDialog1.Filter = isPCM ? "PCM WAV (*.wav)|*.wav|All files (*.*)|*.*" : "ADPCM WAV (*.wav)|*.wav|All files (*.*)|*.*";
 
                 if (saveFileDialog1.ShowDialog() == DialogResult.OK)
                 {
@@ -43,7 +118,7 @@ namespace EPFExplorer
 
         public void ConvertToWAV() {
 
-            byte[] output = new byte[0x3C + filebytes.Length];
+            byte[] output = new byte[(isPCM ? 0x2C : 0x3C) + filebytes.Length];
 
             output[0] = (byte)'R';
             output[1] = (byte)'I';
@@ -67,90 +142,119 @@ namespace EPFExplorer
             output[0x0E] = (byte)'t';
             output[0x0F] = (byte)' ';
 
-            output[0x10] = 0x14;    //fmt chunk length
-            output[0x11] = 0x00;
-            output[0x12] = 0x00;
-            output[0x13] = 0x00;
+            int dataOffset;
 
-            output[0x14] = 0x11;    //ADPCM
-            output[0x15] = 0x00;
+            if (isPCM) {
+                output[0x10] = 0x10;    //fmt chunk length
+                output[0x11] = 0x00;
+                output[0x12] = 0x00;
+                output[0x13] = 0x00;
 
-            output[0x16] = 0x01;    //num channels
-            output[0x17] = 0x00;
+                output[0x14] = 0x01;    //ADPCM
+                output[0x15] = 0x00;
 
-            if (samplerate == 44100)
-            {
-                output[0x18] = 0x44;    //sample rate
-                output[0x19] = 0xAC;
-                output[0x1A] = 0x00;
-                output[0x1B] = 0x00;
+                output[0x16] = 0x01;    //num channels
+                output[0x17] = 0x00;
+
+                if (samplerate == 44100) {
+                    output[0x18] = 0x44;    //sample rate
+                    output[0x19] = 0xAC;
+                    output[0x1A] = 0x00;
+                    output[0x1B] = 0x00;
+                } else {
+                    output[0x18] = 0x22;    //sample rate
+                    output[0x19] = 0x56;
+                    output[0x1A] = 0x00;
+                    output[0x1B] = 0x00;
+                }
+
+                output[0x1C] = 0xA8;    //data rate
+                output[0x1D] = 0x2B;
+                output[0x1E] = 0x00;
+                output[0x1F] = 0x00;
+
+                output[0x20] = 0x02;    //data block size
+                output[0x21] = 0x00;
+
+                output[0x22] = 0x10;    //bits per sample
+                output[0x23] = 0x00;
+
+                dataOffset = 0x24;
+            } else {
+                output[0x10] = 0x14;    //fmt chunk length
+                output[0x11] = 0x00;
+                output[0x12] = 0x00;
+                output[0x13] = 0x00;
+
+                output[0x14] = 0x11;    //ADPCM
+                output[0x15] = 0x00;
+
+                output[0x16] = 0x01;    //num channels
+                output[0x17] = 0x00;
+
+                if (samplerate == 44100) {
+                    output[0x18] = 0x44;    //sample rate
+                    output[0x19] = 0xAC;
+                    output[0x1A] = 0x00;
+                    output[0x1B] = 0x00;
+                } else {
+                    output[0x18] = 0x22;    //sample rate
+                    output[0x19] = 0x56;
+                    output[0x1A] = 0x00;
+                    output[0x1B] = 0x00;
+                }
+
+
+                output[0x1C] = 0xA8;    //data rate
+                output[0x1D] = 0x2B;
+                output[0x1E] = 0x00;
+                output[0x1F] = 0x00;
+
+                output[0x20] = 0xFF;    //data block size apparently, but this works
+                output[0x21] = 0xFF;
+
+                output[0x22] = 0x04;    //bits per sample
+                output[0x23] = 0x00;
+
+                output[0x24] = 0x02;    //idk
+                output[0x25] = 0x00;
+
+                output[0x26] = 0xF9;    //idk
+                output[0x27] = 0x01;
+
+                output[0x28] = (byte)'f';
+                output[0x29] = (byte)'a';
+                output[0x2A] = (byte)'c';
+                output[0x2B] = (byte)'t';
+
+                output[0x2C] = 0x04;
+                output[0x2D] = 0x00;
+                output[0x2E] = 0x00;
+                output[0x2F] = 0x00;
+
+                uint samplecount = (uint)(filebytes.Length * 2);
+
+                output[0x30] = (byte)samplecount;  //sample count
+                output[0x31] = (byte)(samplecount >> 8);
+                output[0x32] = (byte)(samplecount >> 16);
+                output[0x33] = (byte)(samplecount >> 24);
+
+                dataOffset = 0x34;
             }
-            else
-            {
-                output[0x18] = 0x22;    //sample rate
-                output[0x19] = 0x56;
-                output[0x1A] = 0x00;
-                output[0x1B] = 0x00;
-            }
 
+            output[dataOffset] = (byte)'d';
+            output[dataOffset+1] = (byte)'a';
+            output[dataOffset+2] = (byte)'t';
+            output[dataOffset+3] = (byte)'a';
 
-            output[0x1C] = 0xA8;    //data rate
-            output[0x1D] = 0x2B;
-            output[0x1E] = 0x00;
-            output[0x1F] = 0x00;
+            output[dataOffset+4] = (byte)filebytes.Length; //data size (aka, the size of filebytes from before)
+            output[dataOffset+5] = (byte)(filebytes.Length >> 8);
+            output[dataOffset+6] = (byte)(filebytes.Length >> 16);
+            output[dataOffset+7] = (byte)(filebytes.Length >> 24);
 
-            output[0x20] = 0xFF;    //data block size apparently, but this works
-            output[0x21] = 0xFF;
-
-            output[0x22] = 0x04;    //bits per sample
-            output[0x23] = 0x00;
-
-            output[0x24] = 0x02;    //idk
-            output[0x25] = 0x00;
-
-            output[0x26] = 0xF9;    //idk
-            output[0x27] = 0x01;
-
-            output[0x28] = (byte)'f';
-            output[0x29] = (byte)'a';
-            output[0x2A] = (byte)'c';
-            output[0x2B] = (byte)'t';
-
-            output[0x2C] = 0x04;
-            output[0x2D] = 0x00;
-            output[0x2E] = 0x00;
-            output[0x2F] = 0x00;
-
-            uint samplecount = (uint)(filebytes.Length * 2);
-
-            output[0x30] = (byte)samplecount;  //sample count
-            output[0x31] = (byte)(samplecount >> 8);
-            output[0x32] = (byte)(samplecount >> 16);
-            output[0x33] = (byte)(samplecount >> 24);
-
-            output[0x34] = (byte)'d';
-            output[0x35] = (byte)'a';
-            output[0x36] = (byte)'t';
-            output[0x37] = (byte)'a';
-
-            output[0x38] = (byte)filebytes.Length; //data size (aka, the size of filebytes from before)
-            output[0x39] = (byte)(filebytes.Length >> 8);
-            output[0x3A] = (byte)(filebytes.Length >> 16);
-            output[0x3B] = (byte)(filebytes.Length >> 24);
-
-            Array.Copy(filebytes, 0, output, 0x3C, filebytes.Length);   //copy ADPCM data into wav
+            Array.Copy(filebytes, 0, output, dataOffset+8, filebytes.Length);   //copy ADPCM data into wav
 
             filebytes = output;
         }
-
-
-
-
-
-
-
-
-
-
     }
 }

--- a/EPFExplorer/src/FileTypes/sfxfile.cs
+++ b/EPFExplorer/src/FileTypes/sfxfile.cs
@@ -42,12 +42,12 @@ namespace EPFExplorer
 
         public binfile parentbinfile;
 
-        private int[] ima_index_table = new int[]{
+        private static int[] ima_index_table = new int[]{
               -1, -1, -1, -1, 2, 4, 6, 8,
               -1, -1, -1, -1, 2, 4, 6, 8
             };
 
-        private short[] ima_step_table = new short[]{
+        private static short[] ima_step_table = new short[]{
           7, 8, 9, 10, 11, 12, 13, 14, 16, 17,
           19, 21, 23, 25, 28, 31, 34, 37, 41, 45,
           50, 55, 60, 66, 73, 80, 88, 97, 107, 118,
@@ -68,7 +68,7 @@ namespace EPFExplorer
                 return output;
             } else {
                 List<short> output = new List<short>();
-                int predictor = (filebytes[0] | (filebytes[1] << 8));
+                int predictor = (short)(filebytes[0] | (filebytes[1] << 8));
                 int step_index = filebytes[2], step;
                 for (int i = 4; i < filebytes.Length; i++) {
                     int diff;

--- a/EPFExplorer/src/FileTypes/xmfile.cs
+++ b/EPFExplorer/src/FileTypes/xmfile.cs
@@ -464,14 +464,14 @@ namespace EPFExplorer
                 output.Add((byte)(((pcm.Length * 2) >> 16) & 0xFF));
                 output.Add((byte)(((pcm.Length * 2) >> 24) & 0xFF));
                 if (sample != null) {
-                    output.Add((byte)((sample.loopstart * 2) & 0xFF));
-                    output.Add((byte)(((sample.loopstart * 2) >> 8) & 0xFF));
-                    output.Add((byte)(((sample.loopstart * 2) >> 16) & 0xFF));
-                    output.Add((byte)(((sample.loopstart * 2) >> 24) & 0xFF));
-                    output.Add((byte)((( sample.loopend) * 2) & 0xFF));
-                    output.Add((byte)((((sample.loopend) * 2) >> 8) & 0xFF));
-                    output.Add((byte)((((sample.loopend) * 2) >> 16) & 0xFF));
-                    output.Add((byte)((((sample.loopend) * 2) >> 24) & 0xFF));
+                    output.Add((byte)((sample.loopstart * 4) & 0xFF));
+                    output.Add((byte)(((sample.loopstart * 4) >> 8) & 0xFF));
+                    output.Add((byte)(((sample.loopstart * 4) >> 16) & 0xFF));
+                    output.Add((byte)(((sample.loopstart * 4) >> 24) & 0xFF));
+                    output.Add((byte)((( sample.loopend) * 4) & 0xFF));
+                    output.Add((byte)((((sample.loopend) * 4) >> 8) & 0xFF));
+                    output.Add((byte)((((sample.loopend) * 4) >> 16) & 0xFF));
+                    output.Add((byte)((((sample.loopend) * 4) >> 24) & 0xFF));
                 } else {
                     for (int j = 0; j < 8; j++) output.Add(0);
                 }

--- a/EPFExplorer/src/FileTypes/xmfile.cs
+++ b/EPFExplorer/src/FileTypes/xmfile.cs
@@ -177,22 +177,18 @@ namespace EPFExplorer
                         if ((controlBytes[i] & mask) == mask)
                         {
                             //add byte
-                            if ((controlBytes[i] & 0x06) == 0x06) {
+                            if ((controlBytes[i] & 0x06) == 0x06 && (mask == 0x04 || mask == 0x02)) {
                                 if (mask == 0x04) {
                                     output.Add(bin.filebytes[bin.offsetOfMusicInstructionData + pos + 1]);
-                                } else if (mask == 0x02) {
+                                } else {
                                     output.Add(bin.filebytes[bin.offsetOfMusicInstructionData + pos - 1]);
                                     effect = bin.filebytes[bin.offsetOfMusicInstructionData + pos - 1];
-                                } else if (mask == 0x01 && effect == 0x09) {
-                                    output.Add((byte)(bin.filebytes[bin.offsetOfMusicInstructionData + pos] >> 1));
-                                } else {
-                                    output.Add(bin.filebytes[bin.offsetOfMusicInstructionData + pos]);
                                 }
-                            } else if (mask == 0x01 && effect == 0x09) {
+                            } else if (mask == 0x01 && (effect == 0x09 || effect == 0x04)) {
                                 output.Add((byte)(bin.filebytes[bin.offsetOfMusicInstructionData + pos] >> 1));
                             } else {
                                 output.Add(bin.filebytes[bin.offsetOfMusicInstructionData + pos]);
-                                if (mask == 0x02) effect = bin.filebytes[bin.offsetOfMusicInstructionData + pos];
+                                if (mask == 0x04) effect = bin.filebytes[bin.offsetOfMusicInstructionData + pos];
                             }
                             pos++;
                         }

--- a/EPFExplorer/src/FileTypes/xmfile.cs
+++ b/EPFExplorer/src/FileTypes/xmfile.cs
@@ -388,7 +388,6 @@ namespace EPFExplorer
 
             for (int i = 0; i < samples.Count; i++) {
                 sfxfile sample = (i >= 0 && i < samples.Count && samples[i] != null) ? samples[i] : null;
-                if (sample != null) Console.WriteLine("Sample " + i.ToString() + " is at offset " + sample.offset.ToString("X"));
                 output.Add(252);
                 output.Add(0);
                 output.Add(0);

--- a/EPFExplorer/src/FileTypes/xmfile.cs
+++ b/EPFExplorer/src/FileTypes/xmfile.cs
@@ -18,8 +18,6 @@ namespace EPFExplorer
 
         public binfile parentbinfile;
 
-        string moduleName = "default";
-
         public int number_of_patterns_in_one_loop;
         public int restartPosition;
 
@@ -294,14 +292,14 @@ namespace EPFExplorer
                 output.Add((byte)c);
             }
 
-            foreach (char c in moduleName)
+            for (int i = 0; i < Math.Min(name.Length-3, 20); i++)
             {
-                output.Add((byte)c);
+                output.Add((byte)name[i]);
             }
 
             while (output.Count < 0x25)
             {
-                output.Add(0x00);
+                output.Add(0x20);
             }
 
             output.Add(0x1A);

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ A tool for extracting/modifying the files of the Elite Penguin Force DS games.
 - Opening and editing .ARC archives (Both EPF and HR)
 - Opening and editing .RDT resource data files (EPF. HR is viewing/exporting only, and lacks filenames)
 - Opening and editing TSB/MPB tiled images. (Both EPF and HR)
-- Exporting and reimporting LUA scripts.
+- Exporting and reimporting Lua scripts.
 - Editing save files. (Both EPF and HR)
-- Dumping audio clips to .wav (ADPCM format wav, openable if FFMPEG is installed)
-- Exporting and replacing music tracks in .XM format (you will then need to convert these to midi with OpenMPT or similar to actually listen to them, as the XM files have no sample data.)
+- Dumping audio clips to .wav (PCM or ADPCM format wav, openable if FFMPEG is installed)
+- Exporting and replacing music tracks in .XM format, with all sample data
 
 The music replacing also currently has issues with some tracks (e.g. Dojo and Gadget Room, among others)
 


### PR DESCRIPTION
This PR adds full support for ripping music from music archives into XM modules. Partial support was already implemented for pattern data only, but this adds on sample decoding and insertion, and fixes a bunch of errors in the previous audio ripping support. These are the changes that were made:

* All samples are now placed into each XM file
* The sample data is now properly decoded, using a length field and data header instead of guessing (this fixes a bug where PCM samples would get mixed together with ADPCM samples)
    * I've added a comment with a description of the contents of this header. It contains the same sort of data an XM sample header would, as well as envelope information.
* Added support for PCM sample data alongside IMA ADPCM
* Added built-in ADPCM decoding for conversion to XM
* Swapped position of volume and effect type bytes (don't know why they did that)
    * This also fixes erroneous volume as well as missing effects
* Fixed a few effects that had shifted parameters
* Fixed the snake game music by adjusting erroneous transpose values
* The name of each module is now saved in the file 
* Adjusted the formatting of some names

I've tested most of the sounds in both EPF and Herbert's Revenge, and they all sound good to me. However, if you find some problem, I can take a look and fix it.