### PR TITLE
Fixed control bytes for 8 channels, fixed vibrato speed

### DIFF
--- a/EPFExplorer/src/FileTypes/binfile.cs
+++ b/EPFExplorer/src/FileTypes/binfile.cs
@@ -179,7 +179,8 @@ namespace EPFExplorer
                     newSample.defaultvol = filebytes[pos + 14];
                     if (isHR) pos += 22;
                     else pos += 18;
-                    newSample.defaultpan = filebytes[pos];
+                    if (!isHR && i >= 68 && i <= 73) newSample.defaultpan = 0x80; // override for odd right-panned samples
+                    else newSample.defaultpan = filebytes[pos];
 
                     // Hot-patch for Snake Game samples, which have the wrong transpose
                     // (also changing finetune since that seems to make it sound better)

--- a/EPFExplorer/src/FileTypes/xmfile.cs
+++ b/EPFExplorer/src/FileTypes/xmfile.cs
@@ -85,11 +85,13 @@ namespace EPFExplorer
             Byte[] controlBytes = new byte[numchannels];
 
             int b = 0;
+            bool loopStart = true;
 
             while (b < numchannels)
             {
                 controlBytes[b] = (byte)((bin.filebytes[bin.offsetOfMusicInstructionData + pos] & 0xF8) >> 3);
                 b++;
+                loopStart = false;
                 if (b == numchannels) { break; }
 
                 controlBytes[b] = (byte)((bin.filebytes[bin.offsetOfMusicInstructionData + pos] & 0x07) << 2);
@@ -127,10 +129,11 @@ namespace EPFExplorer
                 controlBytes[b] = (byte)(bin.filebytes[bin.offsetOfMusicInstructionData + pos] & 0x1F);
                 b++;
                 pos++;
+                loopStart = true;
                 if (b == numchannels) { break; }
             }
 
-            pos++;
+            if (!loopStart) pos++;
 
             for (int i = 0; i < controlBytes.Length; i++)
                 {
@@ -184,8 +187,10 @@ namespace EPFExplorer
                                     output.Add(bin.filebytes[bin.offsetOfMusicInstructionData + pos - 1]);
                                     effect = bin.filebytes[bin.offsetOfMusicInstructionData + pos - 1];
                                 }
-                            } else if (mask == 0x01 && (effect == 0x09 || effect == 0x04)) {
+                            } else if (mask == 0x01 && effect == 0x09) {
                                 output.Add((byte)(bin.filebytes[bin.offsetOfMusicInstructionData + pos] >> 1));
+                            } else if (mask == 0x01 && effect == 0x04) {
+                                output.Add((byte)((bin.filebytes[bin.offsetOfMusicInstructionData + pos] & 0xF0) | ((bin.filebytes[bin.offsetOfMusicInstructionData + pos] & 0x0F) >> 1)));
                             } else {
                                 output.Add(bin.filebytes[bin.offsetOfMusicInstructionData + pos]);
                                 if (mask == 0x04) effect = bin.filebytes[bin.offsetOfMusicInstructionData + pos];


### PR DESCRIPTION
This PR fixes three things:
1. Modules with a number of channels divisible by 8 ended up skipping the first byte of the row data, causing incorrect rows for these modules (such as Mission Complete). The fix is to only increment the position if it's in between 5 bytes.
2. Vibrato effects used to be too deep, so I fixed that by shifting the parameter by one. However, this ended up halving the speed as well as the depth. The fix is to only shift the low 4 bits down, leaving the high bits intact.
3. The Mission Complete module uses samples that are panned all the way to the right, for some reason. I've made it so that those samples are no longer panned to the right channel.